### PR TITLE
Updating to knox 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "BSD",
   "dependencies": {
     "mime": "~1.2.9",
-    "knox": "~0.8.3",
+    "knox": "~0.9.1",
     "waitress": "~0.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This is highly required as knox has some dependencies which use process.nextTick in a recursive matter.
