### PR TITLE
Add support for sending several Buffers at once. Closes #11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Params:
 Example:
 
 ```JavaScript
-var data = new Buffer('Shall I compare thee to a summer/'s day?')
+var data = new Buffer('Shall I compare thee to a summer\'s day?')
 var headers = {
   'Content-Type': 'application/text',
   'Content-Length': data.length
@@ -151,6 +151,44 @@ client.uploadFiles(files, function(err, res) {
   }
   else {
     console.log('hooray, successfully uploaded all files')
+  }
+})
+```
+
+### `uploadBuffers(buffers, cb)`
+
+Upload an array of buffers. The callback will be called when they all upload
+successfully, or when at least one of the uploads has failed.
+
+Params:
+
+* `buffers` Array of `{data: Buffer, headers: { 'x-amz-acl': 'public-read' }, dest: 'some_uploaded_path.file' }`
+* `cb` `function(err, res)` that will be called when upload is complete or
+  one of the files has failed to upload.
+
+
+Example:
+
+```JavaScript
+var buffers = [
+  {
+    data: new Buffer('Shall I compare thee to a summer\'s day?'),
+    headers: { 'x-amz-acl': 'public-read' }
+    dest: 'some_uploaded_path1.file'
+  },
+  {
+    data: new Buffer('When you need those uploads to back off, use intimidate'),
+    headers: { 'x-amz-acl': 'public-read' }
+    dest: 'some_uploaded_path2.file'
+  }
+]
+
+client.uploadBuffers(buffers, function(err, res) {
+  if (err) {
+    console.log('error uploding one buffer', err)
+  }
+  else {
+    console.log('hooray, successfully uploaded all buffers')
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 intimidate is a node module to upload files to S3 with support for
 automatic retry and exponential backoff.
 
-It uses the excellent [knox](https://github.com/LearnBoost/knox) library to
+It uses the excellent [knox](https://github.com/Automattic/knox) library to
 handle the heavy lifting.
 
 > When you need those uploads to back off, use *intimidate*™. - The Readme
@@ -120,7 +120,7 @@ var headers = {
 
 client.uploadBuffer(data, headers, 'poem_idea.txt', function(err, res) {
   if (err) {
-    console.log('error uplaoding my sweet poem idea', err)
+    console.log('error uploading my sweet poem idea', err)
   }
   else {
     console.log('my poem idea is successfully archived to s3')
@@ -185,7 +185,7 @@ var buffers = [
 
 client.uploadBuffers(buffers, function(err, res) {
   if (err) {
-    console.log('error uploding one buffer', err)
+    console.log('error uploading one buffer', err)
   }
   else {
     console.log('hooray, successfully uploaded all buffers')

--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ Retry.prototype.upload = function(sourcePath, destination, _headers, cb) {
   var self = this
 
   if (typeof _headers === 'function' && typeof cb === 'undefined') {
-    cb = _headers;
-    _headers = {};
+    cb = _headers
+    _headers = {}
   }
 
   fs.readFile(sourcePath, function(err, file) {
@@ -88,7 +88,7 @@ Retry.prototype.upload = function(sourcePath, destination, _headers, cb) {
     // Don't override Content-Type and Content-Length
     for (var prop in _headers) {
       if (_headers.hasOwnProperty(prop) && prop.toLowerCase() != 'content-type' && prop.toLowerCase() != 'content-length') {
-        headers[prop] = _headers[prop];
+        headers[prop] = _headers[prop]
       }
     }
 
@@ -227,15 +227,15 @@ Retry.prototype.uploadWithRetries = function(data, headers, destination, timesRe
  */
 Retry.prototype.uploadFiles = function(files, cb) {
   var self = this
-  var done = waitress(files.length, cb);
+  var done = waitress(files.length, cb)
 
   files.forEach(function(file) {
     if(typeof file.headers === 'object' && file.headers !== null) {
-      self.upload(file.src, file.dest, file.headers, done);
+      self.upload(file.src, file.dest, file.headers, done)
     } else {
-      self.upload(file.src, file.dest, done);
+      self.upload(file.src, file.dest, done)
     }
-  });
+  })
 }
 
 module.exports = Retry

--- a/test/index.js
+++ b/test/index.js
@@ -137,7 +137,7 @@ describe('Intimidate', function() {
       },{
         src: path.join(__dirname, 'fakeFile.txt'),
         dest: 'another_destination'
-      }];
+      }]
 
       client.uploadFiles(files, function(err, res) {
         assert.ifError(err)
@@ -154,7 +154,7 @@ describe('Intimidate', function() {
       },{
         src: path.join(__dirname, 'fakeFile.txt'),
         dest: 'another_destination'
-      }];
+      }]
 
       client.uploadFiles(files, function(err, res) {
         assert(err)
@@ -173,7 +173,7 @@ describe('Intimidate', function() {
       },{
         data: new Buffer('When you need those uploads to back off, use intimidate'),
         dest: 'another_destination'
-      }];
+      }]
 
       client.uploadBuffers(buffers, function(err, res) {
         assert.ifError(err)

--- a/test/index.js
+++ b/test/index.js
@@ -163,4 +163,24 @@ describe('Intimidate', function() {
       })
     })
   })
+
+  describe('uploadBuffers', function() {
+    it('calls the callback with a array response object if the request succeeds', function(done) {
+      var client = new Intimidate({key: 1, secret: 1, bucket: 1 }, successKnox)
+      var buffers = [{
+        data: new Buffer('Shall I compare thee to a summer\'s day?'),
+        dest: 'destination'
+      },{
+        data: new Buffer('When you need those uploads to back off, use intimidate'),
+        dest: 'another_destination'
+      }];
+
+      client.uploadBuffers(buffers, function(err, res) {
+        assert.ifError(err)
+        assert(res)
+        assert(res.length == buffers.length)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
This PR adds the `uploadBuffers()` method and improves `uploadBuffer()` to properly set headers.
